### PR TITLE
Fix query and port parsing

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,7 +106,7 @@ function parseCLIAddress(value: string): CLIAddress {
 /** Parses and validates a port number. */
 function parsePort(value: string): number {
 	const port = Number.parseInt(value);
-	if (!Number.isNaN(port) && 0 < port && port < 0xFFFF) {
+	if (Number.isNaN(port) || 0 > port || port > 0xFFFF) {
 		throw new Error(`Invalid port: ${port}`);
 	}
 	return port;

--- a/src/response.ts
+++ b/src/response.ts
@@ -105,7 +105,7 @@ const TEAM_VALUE_REGEX = /^(\w+)_t(\d+)$/;
 /** Checks if a string is an int */
 const INT_VALUE_REGEX = /^\d+$/;
 /** Checks if a string is a float */
-const FLOAT_VALUE_REGEX = /^\d.\d+$/;
+const FLOAT_VALUE_REGEX = /^\d+\.\d+$/;
 
 
 /**

--- a/src/response.ts
+++ b/src/response.ts
@@ -102,6 +102,10 @@ const HOSTNAME_REGEX = /^\\hostname\\(.*)\\gamever/;
 const PLAYER_VALUE_REGEX = /^(\w+)_(\d+)$/;
 /** Extracts key and index from team values, like "score_t1". */
 const TEAM_VALUE_REGEX = /^(\w+)_t(\d+)$/;
+/** Checks if a string is an int */
+const INT_VALUE_REGEX = /^\d+$/;
+/** Checks if a string is a float */
+const FLOAT_VALUE_REGEX = /^\d.\d+$/;
 
 
 /**
@@ -168,12 +172,17 @@ export function parseServerInfo(data: string): ServerInfo {
 
 /** Parses a server response value into the most appropriate type. */
 function parseValue(value: string): InfoValue {
-	const num = Number.parseInt(value);
-	if (Number.isNaN(num)) {
-		return value === '' ? null : value;
-	} else {
-		return num;
+	if (INT_VALUE_REGEX.test(value)) {
+		const num = Number.parseInt(value);
+		if (!Number.isNaN(num)) return num;
 	}
+
+	if (FLOAT_VALUE_REGEX.test(value)) {
+		const num = Number.parseFloat(value);
+		if (!Number.isNaN(num)) return num;
+	}
+
+	return value === '' ? null : value;
 }
 
 function decodePlayerFlags(value: number): PlayerFlags {


### PR DESCRIPTION
While using this I've found that version strings were incorrectly being parsed like so:
gamever\01.00.10.0621 ->     "gamever": 1,
sapp\10.2.1 CE -> "sapp": 10,

While pinging a specific server to test my fixes I also found that the conditions for port validation from the command line were seemingly all backwards, I've solved this too.